### PR TITLE
Feat/home page top pitches

### DIFF
--- a/client/src/components/TrendingVideos.jsx
+++ b/client/src/components/TrendingVideos.jsx
@@ -12,7 +12,7 @@ const renderColumns = (array, columnAmount) => {
       let innerItem = array[j]
       innerArray.push(innerItem)
     }
-    if (i !== j) { map.push(innerArray) }
+    if (innerArray.length > 0) { map.push(innerArray) }
     if (i + columnAmount >= array.length) {
       leftOverIndex = i
     }

--- a/client/src/components/TrendingVideos.jsx
+++ b/client/src/components/TrendingVideos.jsx
@@ -5,20 +5,27 @@ import { connect } from 'react-redux';
 
 const renderColumns = (array, columnAmount) => {
   let map = []
+  let leftOverIndex = null
   for (var i = 0; i < array.length; i += columnAmount) {
     let innerArray = []
     for (var j = i; j < columnAmount; j++) {
       let innerItem = array[j]
       innerArray.push(innerItem)
     }
-    map.push(innerArray)
+    if (i !== j) { map.push(innerArray) }
+    if (i + columnAmount >= array.length) {
+      leftOverIndex = i
+    }
+  }
+  if (leftOverIndex) {
+    map.push(array.slice(leftOverIndex))
   }
   return <Grid container padded columns={columnAmount}>
-    {map.map(col => {
-      return <Grid.Row>
-        {col.map((pitch, i) => (
-          <Grid.Column>
-            <TrendingVideoCard pitch={pitch} key={i} />
+    {map.map((col, i) => {
+      return <Grid.Row key={i}>
+        {col.map((pitch, j) => (
+          <Grid.Column key={j}>
+            <TrendingVideoCard pitch={pitch} />
           </Grid.Column>
       ))}
     </Grid.Row>

--- a/client/src/components/TrendingVideos.jsx
+++ b/client/src/components/TrendingVideos.jsx
@@ -2,6 +2,30 @@ import React from 'react';
 import TrendingVideoCard from './TrendingVideoCard.jsx'
 import { Card, Divider, Grid, Header, Icon, Image } from 'semantic-ui-react';
 import { connect } from 'react-redux';
+
+const renderColumns = (array, columnAmount) => {
+  let map = []
+  for (var i = 0; i < array.length; i += columnAmount) {
+    let innerArray = []
+    for (var j = i; j < columnAmount; j++) {
+      let innerItem = array[j]
+      innerArray.push(innerItem)
+    }
+    map.push(innerArray)
+  }
+  return <Grid container padded columns={columnAmount}>
+    {map.map(col => {
+      return <Grid.Row>
+        {col.map((pitch, i) => (
+          <Grid.Column>
+            <TrendingVideoCard pitch={pitch} key={i} />
+          </Grid.Column>
+      ))}
+    </Grid.Row>
+  })}
+  </Grid>
+}
+
 const TrendingVideos = (props) => {
   if (props.pitches.length > 0) {
     return (
@@ -13,32 +37,7 @@ const TrendingVideos = (props) => {
           </Header>
         </Divider>
         <Divider hidden />
-
-        <Grid container padded columns={3}>
-          <Grid.Row>
-            <Grid.Column>
-              <TrendingVideoCard pitch={props.pitches[0]} />
-            </Grid.Column>
-            <Grid.Column>
-              <TrendingVideoCard pitch={props.pitches[0]} />
-            </Grid.Column>
-            <Grid.Column>
-              <TrendingVideoCard pitch={props.pitches[0]} />
-            </Grid.Column>
-          </Grid.Row>
-
-          <Grid.Row>
-            <Grid.Column>
-              <TrendingVideoCard pitch={props.pitches[0]} />
-            </Grid.Column>
-            <Grid.Column>
-              <TrendingVideoCard pitch={props.pitches[0]} />
-            </Grid.Column>
-            <Grid.Column>
-              <TrendingVideoCard pitch={props.pitches[0]} />
-            </Grid.Column>
-          </Grid.Row>
-        </Grid>
+        {renderColumns(props.pitches, 3)}
       </section>
     )
   } else {

--- a/client/src/reducers/pitches.js
+++ b/client/src/reducers/pitches.js
@@ -33,7 +33,7 @@ export default function pitches (state = initialState, action) {
         ...state,
         isFetching: false,
         mainPitch: action.pitches[state.index],
-        pitches: action.pitches,
+        pitches: action.pitches.slice(1),
         error: null
       };
     case 'NEXT_PITCH':

--- a/server/db/Pitches.js
+++ b/server/db/Pitches.js
@@ -24,7 +24,7 @@ FROM pitches AS pitchTable
 LEFT JOIN (SELECT count(followers.id) follow_count, pitch_id FROM followers GROUP BY pitch_id) AS followertable
 ON (pitchTable.id = followertable.pitch_id)
 LEFT JOIN (SELECT sum(vote_type) votes, pitch_id FROM votes GROUP BY pitch_id) AS votestable
-ON (pitchTable.id = votestable.pitch_id) WHERE votestable.votes IS NOT NULL ORDER BY votes DESC
+ON (pitchTable.id = votestable.pitch_id) ORDER BY votes DESC NULLS LAST
 LIMIT ${byAmount}
 ;`)
 }

--- a/server/db/Pitches.js
+++ b/server/db/Pitches.js
@@ -24,7 +24,7 @@ FROM pitches AS pitchTable
 LEFT JOIN (SELECT count(followers.id) follow_count, pitch_id FROM followers GROUP BY pitch_id) AS followertable
 ON (pitchTable.id = followertable.pitch_id)
 LEFT JOIN (SELECT sum(vote_type) votes, pitch_id FROM votes GROUP BY pitch_id) AS votestable
-ON (pitchTable.id = votestable.pitch_id) ORDER BY votes DESC
+ON (pitchTable.id = votestable.pitch_id) WHERE votestable.votes IS NOT NULL ORDER BY votes DESC
 LIMIT ${byAmount}
 ;`)
 }


### PR DESCRIPTION
- edit `pitches` reducer to set `mainPitch` state as first index of pitches result and the rest as `pitches` state
- edit `getTopPitches` query to ignore `pitches` where `votes` where `null`
- create `renderColumns`  to take the flat `prop.pitches` array and nest them into an array of n-length column lengths so that we can render out a column by n with rows. 