### PR TITLE
Feat/top trending pitches

### DIFF
--- a/client/src/actions/pitch.js
+++ b/client/src/actions/pitch.js
@@ -14,6 +14,20 @@ const receivePitches = (json) => {
   }
 }
 
+const receiveBothCategoryPitches = (json) => {
+  return {
+    type: 'RECEIVE_BOTH_CATEGORY_PITCHES',
+    pitches: json.data
+  }
+}
+
+const receiveTrendingPitches = (json) => {
+  return {
+    type: 'RECEIVE_TRENDING_PITCHES',
+    pitches: json.data
+  }
+}
+
 const errorPitches = (err) => {
   return {
     type: 'REQUEST_PITCHES_ERROR',
@@ -30,11 +44,30 @@ export function fetchPitches(category = 'all') {
   }
 }
 
+export function fetchBothCategoryPitches(category = 'both') {
+  return function(dispatch) {
+    dispatch(requestPitches());
+    //We can possibly define categories here?
+    axios.get('http://localhost:8080/api/pitches?q=both')
+    .then(results => dispatch(receivePitches(results)))
+    .catch(error => dispatch(errorPitches(error)))
+  }
+}
+
 export function fetchTopPitches(category = 'top') {
   return function(dispatch) {
     dispatch(requestPitches());
     axios.get('http://localhost:8080/api/pitches?q=top')
     .then(results => dispatch(receivePitches(results)))
+    .catch(error => dispatch(errorPitches(error)))
+  }
+}
+
+export function fetchTrendingPitches(category = 'trending') {
+  return function(dispatch) {
+    dispatch(requestPitches());
+    axios.get('http://localhost:8080/api/pitches?q=trending')
+    .then(results => dispatch(receiveTrendingPitches(results)))
     .catch(error => dispatch(errorPitches(error)))
   }
 }

--- a/client/src/actions/pitch.js
+++ b/client/src/actions/pitch.js
@@ -49,7 +49,7 @@ export function fetchBothCategoryPitches(category = 'both') {
     dispatch(requestPitches());
     //We can possibly define categories here?
     axios.get('http://localhost:8080/api/pitches?q=both')
-    .then(results => dispatch(receivePitches(results)))
+    .then(results => dispatch(receiveBothCategoryPitches(results)))
     .catch(error => dispatch(errorPitches(error)))
   }
 }

--- a/client/src/actions/pitchCategory.js
+++ b/client/src/actions/pitchCategory.js
@@ -1,0 +1,11 @@
+export const setPitchCategoryToTop = () => {
+  return {
+    type: 'TRENDING_PITCH'
+  }
+}
+
+export const setPitchCategoryToTrending = () => {
+  return {
+    type: 'TOP_PITCH'
+  }
+}

--- a/client/src/actions/signIn.js
+++ b/client/src/actions/signIn.js
@@ -42,11 +42,5 @@ export function signIn(username, password) {
         dispatch(signInError(err));
       }
     });
-    // axios.post('http://localhost:8080/auth/signin', {username, password} )
-    // .then((results) => {
-    //   console.log('hehehehehehe');
-    //   dispatch(completeSignIn(results.data.username, results.data.user_id));
-    // })
-    // .catch(error => dispatch(signInError(error)))
   };
 }

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -42,7 +42,6 @@ class App extends Component {
 }
 
 const mapStateToProps = (state) => {
-  console.log('App.js ', state);
   return {
     topPitches: state.pitches.topPitches,
     trendingPitches: state.pitches.trendingPitches ? state.pitches.trendingPitches : null,

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -5,7 +5,7 @@ import TrendingVideos from './TrendingVideos.jsx';
 import axios from 'axios';
 import { Container, Dimmer, Divider, Loader } from 'semantic-ui-react';
 import { connect } from 'react-redux';
-import { fetchTopPitches } from '../actions/pitch';
+import { fetchBothCategoryPitches } from '../actions/pitch';
 
 class App extends Component {
   constructor(props) {
@@ -14,7 +14,7 @@ class App extends Component {
 
   componentWillMount() {
     const {dispatch} = this.props;
-    dispatch(fetchTopPitches())
+    dispatch(fetchBothCategoryPitches())
   }
 
   render() {
@@ -42,8 +42,10 @@ class App extends Component {
 }
 
 const mapStateToProps = (state) => {
+  console.log('App.js ', state);
   return {
-    pitches: state.pitches.pitches,
+    topPitches: state.pitches.topPitches,
+    trendingPitches: state.pitches.trendingPitches ? state.pitches.trendingPitches : null,
     mainPitch: state.pitches.mainPitch
   }
 }

--- a/client/src/components/CompaniesList.jsx
+++ b/client/src/components/CompaniesList.jsx
@@ -15,8 +15,6 @@ class CompaniesList extends Component {
   }
 
   render() {
-    console.log('alksfaslkdjf', this.props);
-
     if (this.props.pitches.length > 0) {
       return (
         <Container text>

--- a/client/src/components/TrendingVideos.jsx
+++ b/client/src/components/TrendingVideos.jsx
@@ -11,7 +11,7 @@ const renderColumns = (array, columnAmount) => {
     let innerArray = []
     for (var j = i; j < columnAmount; j++) {
       let innerItem = array[j]
-      innerArray.push(innerItem)
+      if (innerItem) { innerArray.push(innerItem) }
     }
     if (innerArray.length > 0) { map.push(innerArray) }
     if (i + columnAmount >= array.length) {
@@ -49,9 +49,9 @@ class TrendingVideos extends React.Component {
           </Header>
         </Divider>
         <Divider hidden />
-        <Menu attached='top'>
-          <Menu.Item name='trending' active={this.props.pitchCategory === 'trending'} onClick={this.props.setPitchCategoryToTrending} />
-          <Menu.Item name='top' active={this.props.pitchCategory === 'top'} onClick={this.props.setPitchCategoryToTop} />
+        <Menu attached='top' tabular>
+          <Menu.Item name='trending' active={this.props.pitchCategory === 'trending'} onClick={this.props.setPitchCategoryToTop} />
+          <Menu.Item name='top' active={this.props.pitchCategory === 'top'} onClick={this.props.setPitchCategoryToTrending} />
         </Menu>
         <Segment attached='bottom'>
           {this.props.pitches.length > 0 ? renderColumns(this.props.pitches, 3) : <div>There is currently no {this.props.pitchCategory} pitches.</div>}

--- a/client/src/components/TrendingVideos.jsx
+++ b/client/src/components/TrendingVideos.jsx
@@ -34,32 +34,6 @@ const renderColumns = (array, columnAmount) => {
   </Grid>
 }
 
-// const TrendingVideos = (props) => {
-//   console.log('TrendingVideos props ', props);
-//   if (props.pitches.length > 0) {
-//     return (
-//       <section>
-//         <Divider horizontal>
-//           <Header as='h4'>
-//             <Icon name='line chart' />
-//             Trending Pitches
-//           </Header>
-//         </Divider>
-//         <Divider hidden />
-//         <Menu attached='top'>
-//           <Menu.Item name='trending' active={props.pitchCategory === 'trending'} onClick={this.props.setPitchCategoryToTrending} />
-//           <Menu.Item name='top' active={props.pitchCategory === 'top'} onClick={this.props.setPitchCategoryToTop} />
-//         </Menu>
-//         <Segment attached='bottom'>
-//           {renderColumns(props.pitches, 3)}
-//         </Segment>
-//       </section>
-//     )
-//   } else {
-//     return null
-//   }
-// }
-
 class TrendingVideos extends React.Component {
   constructor(props) {
     super(props)
@@ -88,7 +62,6 @@ class TrendingVideos extends React.Component {
 }
 
 const mapStateToProps = (state) => {
-  console.log('TrendingVideos.js ', state.pitches);
   return {
     pitches: state.pitchCategory === 'top' ? state.pitches.topPitches : state.pitches.trendingPitches,
     pitchCategory: state.pitchCategory

--- a/client/src/components/TrendingVideos.jsx
+++ b/client/src/components/TrendingVideos.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import TrendingVideoCard from './TrendingVideoCard.jsx'
-import { Card, Divider, Grid, Header, Icon, Image } from 'semantic-ui-react';
+import { Card, Divider, Grid, Header, Icon, Image, Menu, Segment } from 'semantic-ui-react';
+import { setPitchCategoryToTop, setPitchCategoryToTrending } from '../actions/pitchCategory'
 import { connect } from 'react-redux';
 
 const renderColumns = (array, columnAmount) => {
@@ -33,31 +34,72 @@ const renderColumns = (array, columnAmount) => {
   </Grid>
 }
 
-const TrendingVideos = (props) => {
-  if (props.pitches.length > 0) {
+// const TrendingVideos = (props) => {
+//   console.log('TrendingVideos props ', props);
+//   if (props.pitches.length > 0) {
+//     return (
+//       <section>
+//         <Divider horizontal>
+//           <Header as='h4'>
+//             <Icon name='line chart' />
+//             Trending Pitches
+//           </Header>
+//         </Divider>
+//         <Divider hidden />
+//         <Menu attached='top'>
+//           <Menu.Item name='trending' active={props.pitchCategory === 'trending'} onClick={this.props.setPitchCategoryToTrending} />
+//           <Menu.Item name='top' active={props.pitchCategory === 'top'} onClick={this.props.setPitchCategoryToTop} />
+//         </Menu>
+//         <Segment attached='bottom'>
+//           {renderColumns(props.pitches, 3)}
+//         </Segment>
+//       </section>
+//     )
+//   } else {
+//     return null
+//   }
+// }
+
+class TrendingVideos extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
     return (
       <section>
         <Divider horizontal>
           <Header as='h4'>
             <Icon name='line chart' />
-            Trending Pitches
+            {this.props.pitchCategory[0].toUpperCase() + this.props.pitchCategory.slice(1)} Pitches
           </Header>
         </Divider>
         <Divider hidden />
-        {renderColumns(props.pitches, 3)}
+        <Menu attached='top'>
+          <Menu.Item name='trending' active={this.props.pitchCategory === 'trending'} onClick={this.props.setPitchCategoryToTrending} />
+          <Menu.Item name='top' active={this.props.pitchCategory === 'top'} onClick={this.props.setPitchCategoryToTop} />
+        </Menu>
+        <Segment attached='bottom'>
+          {this.props.pitches.length > 0 ? renderColumns(this.props.pitches, 3) : <div>There is currently no {this.props.pitchCategory} pitches.</div>}
+        </Segment>
       </section>
-    )
-  } else {
-    return (
-      <div>NOPE!</div>
     )
   }
 }
 
 const mapStateToProps = (state) => {
+  console.log('TrendingVideos.js ', state.pitches);
   return {
-    pitches: state.pitches.pitches
+    pitches: state.pitchCategory === 'top' ? state.pitches.topPitches : state.pitches.trendingPitches,
+    pitchCategory: state.pitchCategory
   }
 }
 
-export default connect(mapStateToProps)(TrendingVideos)
+const mapDispatchToProps = (dispatch) => {
+  return {
+    setPitchCategoryToTop: () => dispatch(setPitchCategoryToTop()),
+    setPitchCategoryToTrending: () => dispatch(setPitchCategoryToTrending())
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(TrendingVideos)

--- a/client/src/components/Video.jsx
+++ b/client/src/components/Video.jsx
@@ -27,11 +27,4 @@ let Video = (props) => {
   }
 }
 
-
-const mapStateToProps = (state) => {
-  return {
-    video: state.mainPitch.video
-  }
-}
-
 export default Video;

--- a/client/src/reducers/pitchCategory.js
+++ b/client/src/reducers/pitchCategory.js
@@ -1,0 +1,12 @@
+const pitchCategory = (state='top', action) => {
+  switch (action.type) {
+    case 'TRENDING_PITCH':
+      return 'trending'
+    case 'TOP_PITCH':
+      return 'top'
+    default:
+      return state
+  }
+}
+
+export default pitchCategory

--- a/client/src/reducers/pitches.js
+++ b/client/src/reducers/pitches.js
@@ -1,7 +1,8 @@
 const initialState = {
   isFetching: false,
   mainPitch: {},
-  pitches: [],
+  topPitches: [],
+  trendingPitches: [],
   error: null,
   index: 0
 }
@@ -28,12 +29,29 @@ export default function pitches (state = initialState, action) {
         mainPitch: state.pitches.filter(pitch => pitch.id === action.pitchId)[0],
         index: pitchIdArray.indexOf(action.pitchId)
       };
+    case 'RECEIVE_BOTH_CATEGORY_PITCHES':
+      return {
+        ...state,
+        isFetching: false,
+        mainPitch: action.pitches.trendingPitches ? action.pitches.trendingPitches : action.pitches.topPitches,
+        trendingPitches: action.pitches.trendingPitches ? action.pitches.trendingPitches : [],
+        topPitches: action.pitches.topPitches ? action.pitches.topPitches : [],
+        error: null
+      }
+    case 'RECEIVE_TRENDING_PITCHES':
+      return {
+        ...state,
+        isFetching: false,
+        mainPitch: action.pitches.trendingPitches[state.index],
+        trendingPitches: action.pitches.trendingPitches.slice(1),
+        error: null
+      };
     case 'RECEIVE_PITCHES':
       return {
         ...state,
         isFetching: false,
-        mainPitch: action.pitches[state.index],
-        pitches: action.pitches.slice(1),
+        mainPitch: action.pitches.topPitches[state.index],
+        topPitches: action.pitches.topPitches.slice(1),
         error: null
       };
     case 'NEXT_PITCH':

--- a/client/src/reducers/pitches.js
+++ b/client/src/reducers/pitches.js
@@ -33,11 +33,12 @@ export default function pitches (state = initialState, action) {
       return {
         ...state,
         isFetching: false,
-        mainPitch: action.pitches.trendingPitches ? action.pitches.trendingPitches : action.pitches.topPitches,
+        mainPitch: action.pitches.trendingPitches ? action.pitches.trendingPitches[0] : action.pitches.topPitches[0],
         trendingPitches: action.pitches.trendingPitches ? action.pitches.trendingPitches : [],
         topPitches: action.pitches.topPitches ? action.pitches.topPitches : [],
         error: null
       }
+      /*
     case 'RECEIVE_TRENDING_PITCHES':
       return {
         ...state,
@@ -54,6 +55,7 @@ export default function pitches (state = initialState, action) {
         topPitches: action.pitches.topPitches.slice(1),
         error: null
       };
+      */
     case 'NEXT_PITCH':
       let nextIndex = state.index + 1;
       return {

--- a/client/src/reducers/rootReducers.js
+++ b/client/src/reducers/rootReducers.js
@@ -7,8 +7,10 @@ import createUser from './createUser';
 import signIn from './signIn';
 import userPage from './userPage';
 import comments from './comments';
+import pitchCategory from './pitchCategory'
 
 const appReducer = combineReducers({
+  pitchCategory,
   pitches,
   pitchPage,
   createPitch,

--- a/server/db/Pitches.js
+++ b/server/db/Pitches.js
@@ -31,21 +31,11 @@ LIMIT ${byAmount}
 
 module.exports.getTrendingPitches = (byAmount = 10) => {
 	return db.query(`
-SELECT
-	pitchTable.*, followertable.follow_count, votestable.votes
-FROM
-	pitches AS pitchTable
-LEFT JOIN
-	(SELECT count(followers.id) follow_count, pitch_id FROM followers GROUP BY pitch_id) AS followertable
-	ON (pitchTable.id = followertable.pitch_id)
-RIGHT JOIN
-	(SELECT sum(vote_type) votes, pitch_id FROM votes WHERE (extract(day from age(now(), timestamp)) < 1) GROUP BY pitch_id)
-	AS votestable
-	ON (pitchTable.id = votestable.pitch_id)
-ORDER BY
-	votes DESC NULLS LAST
-LIMIT ${byAmount}
-;`)
+SELECT pitchTable.*, followertable.follow_count, votestable.votes
+FROM pitches AS pitchTable
+LEFT JOIN (SELECT count(followers.id) follow_count, pitch_id FROM followers GROUP BY pitch_id) AS followertable ON (pitchTable.id = followertable.pitch_id)
+RIGHT JOIN (SELECT sum(vote_type) votes, pitch_id FROM votes WHERE (extract(day from age(now(), timestamp)) < 1) GROUP BY pitch_id) AS votestable ON (pitchTable.id = votestable.pitch_id)
+ORDER BY votes DESC NULLS LAST LIMIT ${byAmount};`)
 }
 
 

--- a/server/db/Pitches.js
+++ b/server/db/Pitches.js
@@ -29,6 +29,26 @@ LIMIT ${byAmount}
 ;`)
 }
 
+module.exports.getTrendingPitches = (byAmount = 10) => {
+	return db.query(`
+SELECT
+	pitchTable.*, followertable.follow_count, votestable.votes
+FROM
+	pitches AS pitchTable
+LEFT JOIN
+	(SELECT count(followers.id) follow_count, pitch_id FROM followers GROUP BY pitch_id) AS followertable
+	ON (pitchTable.id = followertable.pitch_id)
+RIGHT JOIN
+	(SELECT sum(vote_type) votes, pitch_id FROM votes WHERE (extract(day from age(now(), timestamp)) < 1) GROUP BY pitch_id)
+	AS votestable
+	ON (pitchTable.id = votestable.pitch_id)
+ORDER BY
+	votes DESC NULLS LAST
+LIMIT ${byAmount}
+;`)
+}
+
+
 //add pitch, needs all info:
 module.exports.getPitchByPitchId = (pitchId) => {
   return db.query(`SELECT * from pitches where id = ${pitchId};`)

--- a/server/routes/Pitches.js
+++ b/server/routes/Pitches.js
@@ -15,6 +15,22 @@ module.exports.getPitches = (req, res, next) => {
         .then(results => res.status(200).send(results.rows))
         .catch(error => res.status(404).json(error));
     }
+  } else if (q === 'both') {
+    let data = {}
+    Pitch.getTrendingPitches(10)
+      .then(results => data.trendingPitches = results.rows)
+      .then(() => {
+        return Pitch.getTopPitches(10)
+      })
+      .then(results => {
+        data.topPitches = results.rows
+        res.status(200).send(data)
+      })
+      .catch(error => res.status(404).json(error));
+  } else if (q === 'trending') {
+    Pitch.getTrendingPitches(10)
+      .then(results => res.status(200).send(results.rows))
+      .catch(error => res.status(404).json(error));
   } else if (q === 'top') {
     Pitch.getTopPitches(10)
       .then(results => res.status(200).send(results.rows))


### PR DESCRIPTION
- create actions and thunk middleware to query both or trending pitches
- have `App.jsx` fetch both pitches (trending and top)
- replace functional stateless function to class in `TrendingVideos`, edit `map*ToProps` functions to map state from newly created reducers specific to pitch category
- add new reducer case statement to reduce state with both category pitches
- add `getTrendingPitches` DB query to fetch trending pitches and create route specific for this request.
- remove comments and unused code